### PR TITLE
feat: Allow to not send 400 error if email does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ you should always have it on email. `EMAIL_FIELD` is on default on email.
  `), or, in the default way (`False`). Note that the status of the token should also
   be set to `ACCEPTED` if the password was set successfully.
 
+`RETURN_EMAIL_NOT_FOUND_ERROR` - A boolean which specifies if the reset password request should return a 400 error
+if the email does not exist in the system. The default value is `True`. If set to `False`, the endpoint will return a 201
+status code
 
 ## Template Creation 
 

--- a/README.rst
+++ b/README.rst
@@ -76,6 +76,10 @@ saved in a custom way, when catching the ``custom_password_update`` signal
 (``True``), or, in the default way (``False``). Note that the status of the token
 should also be set to ``ACCEPTED`` if the password was set successfully.
 
+``RETURN_EMAIL_NOT_FOUND_ERROR`` - A boolean which specifies if the reset password request should return a 400 error
+if the email does not exist in the system. The default value is ``True``. If set to ``False``, the endpoint will return a 201
+status code
+
 
 Template Creation
 #################

--- a/reset_password/views.py
+++ b/reset_password/views.py
@@ -24,6 +24,9 @@ class ResetPasswordView(mixins.CreateModelMixin, viewsets.GenericViewSet):
         user = User.objects.filter(email=request.data["email"]).first()
         if user:
             user = user.id
+        elif user is None and settings.DRF_RESET_EMAIL.get("RETURN_EMAIL_NOT_FOUND_ERROR", True) is False:
+            return Response(status=status.HTTP_201_CREATED)
+
         serializer = self.get_serializer(data={"user": user})
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -82,7 +82,6 @@ DRF_RESET_EMAIL = {
     'EMAIL_PROVIDER': 'reset_password.models.EmailProvider',
     'EMAIL_FIELD': 'email',
     'CUSTOM_PASSWORD_SET': False,
-    'TEST_ENV': True,
 }
 
 LANGUAGE_CODE = 'en-us'

--- a/tests/test/test_reset_password.py
+++ b/tests/test/test_reset_password.py
@@ -1,10 +1,11 @@
 import json
+from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from reset_password.models import ResetPasswordToken
+from reset_password.models import ResetPasswordToken, EmailProvider
 from tests.test.api_set_up import APISetUp
 
 
@@ -22,62 +23,73 @@ class AuthTestCase(APITestCase, APISetUp):
         decoded_response = json.loads(response.content.decode())
         self.assertTrue("user" in decoded_response)
 
-    def test_validate_token(self):
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 0)
-
-        response = self.reset_password_create(email="user1@mail.com")
+    def test_try_reset_password_email_does_not_exist_without_error(self):
+        DRF_RESET_EMAIL = {
+            'RETURN_EMAIL_NOT_FOUND_ERROR': False,
+        }
+        with self.settings(DRF_RESET_EMAIL=DRF_RESET_EMAIL):
+            response = self.reset_password_create("tas@mail.com")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
-        valid_token = str(ResetPasswordToken.objects.filter(user=self.user1).first().token)
-        response = self.reset_password_validation(valid_token)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    def test_validate_token(self):
+        self.assertEqual(ResetPasswordToken.objects.all().count(), 0)
+        with patch.object(EmailProvider, 'send_email'):
+            response = self.reset_password_create(email="user1@mail.com")
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        response = self.reset_password_validation("bad token")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
+            valid_token = str(ResetPasswordToken.objects.filter(user=self.user1).first().token)
+            response = self.reset_password_validation(valid_token)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            response = self.reset_password_validation("bad token")
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_reset_password(self):
         self.assertEqual(ResetPasswordToken.objects.all().count(), 0)
+        with patch.object(EmailProvider, 'send_email'):
+            response = self.reset_password_create(email=self.user2.email)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
-        response = self.reset_password_create(email=self.user2.email)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
-        valid_token = str(ResetPasswordToken.objects.filter(user=self.user2).first().token)
-        response = self.reset_password_submit(valid_token, "haha")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        user = User.objects.get(id=self.user2.id)
-        self.assertEqual(user.check_password("haha"), True)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
+            valid_token = str(ResetPasswordToken.objects.filter(user=self.user2).first().token)
+            response = self.reset_password_submit(valid_token, "haha")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            user = User.objects.get(id=self.user2.id)
+            self.assertEqual(user.check_password("haha"), True)
 
     def test_multiple_tokens(self):
-        response = self.reset_password_create(email=self.user2.email)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
+        with patch.object(EmailProvider, 'send_email'):
+            response = self.reset_password_create(email=self.user2.email)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
 
-        response = self.reset_password_create(email=self.user2.email)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 2)
+            response = self.reset_password_create(email=self.user2.email)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 2)
 
-        response = self.reset_password_create(email=self.user2.email)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 3)
-        self.assertEqual(ResetPasswordToken.objects.filter(status="invalid").count(), 2)
+            response = self.reset_password_create(email=self.user2.email)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 3)
+            self.assertEqual(ResetPasswordToken.objects.filter(status="invalid").count(), 2)
 
     def test_accepted(self):
-        self.reset_password_create(email=self.user2.email)
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
-        valid_token = str(ResetPasswordToken.objects.filter(user=self.user2).first().token)
-        response = self.reset_password_submit(valid_token, "haha")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        with patch.object(EmailProvider, 'send_email'):
+            self.reset_password_create(email=self.user2.email)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
+            valid_token = str(ResetPasswordToken.objects.filter(user=self.user2).first().token)
+            response = self.reset_password_submit(valid_token, "haha")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        response = self.reset_password_create(email=self.user2.email)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 2)
+            response = self.reset_password_create(email=self.user2.email)
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 2)
 
     def test_same_password(self):
-        self.reset_password_create(email=self.user2.email)
-        self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
-        valid_token = str(ResetPasswordToken.objects.filter(user=self.user2).first().token)
+        with patch.object(EmailProvider, 'send_email'):
+            self.reset_password_create(email=self.user2.email)
+            self.assertEqual(ResetPasswordToken.objects.all().count(), 1)
+            valid_token = str(ResetPasswordToken.objects.filter(user=self.user2).first().token)
 
-        response = self.reset_password_submit(valid_token, "secret2")
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            response = self.reset_password_submit(valid_token, "secret2")
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- If the `RETURN_EMAIL_NOT_FOUND_ERROR` is set to `False` the `/reset-password` endpoint will not return a 400 error if the email does not exist in the system
- Fixed failing tests